### PR TITLE
chore(deps): bump the python-packages group across 1 directory with 3…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   #     https://github.com/notypecheck/passlib
   "libpass==1.9.3",
   # Hypothesis for hard-core ip_address tests
-  "hypothesis==6.140.3",
+  "hypothesis==6.141.0",
 ]
 authors = [
   { name = "Mike Pennington", email = "mike@pennington.net" },
@@ -69,13 +69,13 @@ dev = [
   "pre-commit==4.3.0",
   "black==25.9.0",
   "pyupgrade==3.21.0",
-  "yamlfix==1.18.0",
+  "yamlfix==1.19.0",
   "pylama==8.4.1",
   "pylint==3.3.9",
   "coverage>=7.3.2",
   "pytest-cov>=4.1.0",
   "pyroma==5.0",
-  "invoke==2.2.0",
+  "invoke==2.2.1",
   "fabric==3.2.2",
   "commitizen>=2.40.0",
   "python-lsp-server>=1.12.2",


### PR DESCRIPTION
… updates

Bumps the python-packages group with 3 updates in the / directory: [hypothesis](https://github.com/HypothesisWorks/hypothesis), [yamlfix](https://github.com/lyz-code/yamlfix) and [invoke](https://github.com/pyinvoke/invoke).


Updates `hypothesis` from 6.140.3 to 6.141.0
- [Release notes](https://github.com/HypothesisWorks/hypothesis/releases)
- [Commits](https://github.com/HypothesisWorks/hypothesis/compare/hypothesis-python-6.140.3...hypothesis-python-6.141.0)

Updates `yamlfix` from 1.18.0 to 1.19.0
- [Changelog](https://github.com/lyz-code/yamlfix/blob/main/CHANGELOG.md)
- [Commits](https://github.com/lyz-code/yamlfix/commits)

Updates `invoke` from 2.2.0 to 2.2.1
- [Commits](https://github.com/pyinvoke/invoke/compare/2.2.0...2.2.1)

---
updated-dependencies:
- dependency-name: hypothesis dependency-version: 6.141.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: python-packages
- dependency-name: yamlfix dependency-version: 1.19.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: python-packages
- dependency-name: invoke dependency-version: 2.2.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-packages ...